### PR TITLE
DAP-1026: Validate submission agreement

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
 	"scripts": {
 		"test": "jest",
 		"dev": "nodemon",
-		"build": "tsc"
+		"build": "tsc",
+		"run-node": "tsx -r tsconfig-paths/register"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "3.677.0",
@@ -18,6 +19,7 @@
 		"express": "4.21.0",
 		"express-rate-limit": "7.4.1",
 		"mongoose": "8.7.0",
+		"pdfjs-dist": "4.9.124",
 		"pdfkit": "0.15.1",
 		"tsconfig-paths": "4.2.0",
 		"typescript": "5.6.2",
@@ -38,6 +40,7 @@
 		"nodemon": "3.1.7",
 		"supertest": "7.0.0",
 		"ts-jest": "29.2.5",
+		"ts-node": "10.9.2",
 		"tsx": "4.19.1"
 	}
 }

--- a/backend/src/modules/transfer/utils/index.ts
+++ b/backend/src/modules/transfer/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./validateStandardTransferStructure";
+export * from "./validateSubmissionAgreement";

--- a/backend/src/modules/transfer/utils/validateSubmissionAgreement.ts
+++ b/backend/src/modules/transfer/utils/validateSubmissionAgreement.ts
@@ -1,0 +1,81 @@
+import { getDocument } from "pdfjs-dist";
+import { HttpError, HTTP_STATUS_CODES } from "@bcgov/citz-imb-express-utilities";
+import type { Buffer } from "node:buffer";
+
+type Data = {
+	buffer: Buffer;
+	accession: string;
+	application: string;
+};
+
+// Polyfill
+if (!Promise.withResolvers) {
+	Promise.withResolvers = <T>() => {
+		let resolve: (value: T | PromiseLike<T>) => void;
+		// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+		let reject: (reason?: any) => void;
+
+		const promise = new Promise<T>((res, rej) => {
+			resolve = res;
+			reject = rej;
+		});
+
+		// biome-ignore lint/style/noNonNullAssertion: <explanation>
+		return { promise, resolve: resolve!, reject: reject! };
+	};
+}
+
+export const validateSubmissionAgreement = async ({
+	buffer,
+	accession,
+	application,
+}: Data): Promise<void> => {
+	try {
+		// Convert Buffer to Uint8Array
+		const data = new Uint8Array(buffer);
+
+		const loadingTask = getDocument({ data });
+		const pdf = await loadingTask.promise;
+
+		let fullText = "";
+
+		// Extract text from each page
+		for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+			const page = await pdf.getPage(pageNum);
+			const textContent = await page.getTextContent();
+			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			fullText += textContent.items.map((item) => (item as any).str).join(" ");
+		}
+
+		const expectedAccessionApplicationText = `Accession # ${accession} and Application # ${application}`;
+
+		// Validate the content for correct accession and application #s
+		if (!fullText.includes(expectedAccessionApplicationText)) {
+			throw new HttpError(
+				HTTP_STATUS_CODES.BAD_REQUEST,
+				"Incorrect or missing accession and application numbers.",
+			);
+		}
+	} catch (error) {
+		if (error instanceof Error) {
+			// Handle errors with `message` property
+			if (error.message.includes("Invalid PDF structure")) {
+				throw new HttpError(
+					HTTP_STATUS_CODES.BAD_REQUEST,
+					"Invalid file: The provided buffer is not a valid PDF.",
+				);
+			}
+
+			throw new HttpError(
+				HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
+				`An error occurred while validating the PDF: ${error.message}`,
+			);
+		}
+
+		// Fallback for non-Error objects
+		throw new HttpError(
+			HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
+			"An unknown error occurred while validating the PDF.",
+		);
+	}
+};

--- a/backend/tests/modules/transfer/utils/validateSubmissionAgreement.test.ts
+++ b/backend/tests/modules/transfer/utils/validateSubmissionAgreement.test.ts
@@ -1,0 +1,89 @@
+import { validateSubmissionAgreement } from "@/modules/transfer/utils/validateSubmissionAgreement";
+import { HttpError } from "@bcgov/citz-imb-express-utilities";
+import { getDocument } from "pdfjs-dist";
+
+// Mock dependencies
+jest.mock("pdfjs-dist", () => ({
+	getDocument: jest.fn(),
+}));
+
+describe("validateSubmissionAgreement", () => {
+	const mockBuffer = Buffer.from("mock data");
+	const accession = "123";
+	const application = "456";
+
+	const createMockPDF = (numPages: number, textContents: string[]) => ({
+		promise: Promise.resolve({
+			numPages,
+			getPage: jest.fn().mockImplementation((pageNum) => ({
+				getTextContent: jest.fn().mockResolvedValue({
+					items: textContents[pageNum - 1].split(" ").map((str) => ({ str })),
+				}),
+			})),
+		}),
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("should validate the PDF successfully", async () => {
+		// Test case: Valid PDF with correct text
+		const mockPDF = createMockPDF(1, [`Accession # ${accession} and Application # ${application}`]);
+		(getDocument as jest.Mock).mockReturnValue(mockPDF);
+
+		await expect(
+			validateSubmissionAgreement({ buffer: mockBuffer, accession, application }),
+		).resolves.not.toThrow();
+	});
+
+	it("should throw an error if accession and application numbers are incorrect", async () => {
+		// Test case: PDF missing expected text
+		const mockPDF = createMockPDF(1, ["Some unrelated text"]);
+		(getDocument as jest.Mock).mockReturnValue(mockPDF);
+
+		await expect(
+			validateSubmissionAgreement({ buffer: mockBuffer, accession, application }),
+		).rejects.toEqual(
+			new HttpError(
+				400,
+				"An error occurred while validating the PDF: Incorrect or missing accession and application numbers.",
+			),
+		);
+	});
+
+	it("should throw an error for invalid PDF structure", async () => {
+		// Test case: Invalid PDF structure
+		(getDocument as jest.Mock).mockImplementation(() => ({
+			promise: Promise.reject(new Error("Invalid PDF structure")),
+		}));
+
+		await expect(
+			validateSubmissionAgreement({ buffer: mockBuffer, accession, application }),
+		).rejects.toEqual(new HttpError(400, "Invalid file: The provided buffer is not a valid PDF."));
+	});
+
+	it("should handle unexpected errors gracefully", async () => {
+		// Test case: Unexpected error
+		(getDocument as jest.Mock).mockImplementation(() => ({
+			promise: Promise.reject(new Error("Unexpected error")),
+		}));
+
+		await expect(
+			validateSubmissionAgreement({ buffer: mockBuffer, accession, application }),
+		).rejects.toEqual(
+			new HttpError(500, "An error occurred while validating the PDF: Unexpected error"),
+		);
+	});
+
+	it("should throw a generic error for non-Error objects", async () => {
+		// Test case: Non-error object thrown
+		(getDocument as jest.Mock).mockImplementation(() => ({
+			promise: Promise.reject("Non-error object"),
+		}));
+
+		await expect(
+			validateSubmissionAgreement({ buffer: mockBuffer, accession, application }),
+		).rejects.toEqual(new HttpError(500, "An unknown error occurred while validating the PDF."));
+	});
+});


### PR DESCRIPTION
## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[DAP-1026](https://citz-cirmo.atlassian.net/browse/DAP-1026)

Waiting for `DAP-1022` to be merged.

<!-- PROVIDE BELOW an explanation of your changes and any supporting images -->
To test:

1. Create the file `backend\src\modules\transfer\utils\test.ts`

```
import fs from "node:fs/promises";
import path from "node:path";
import { validateSubmissionAgreement } from "./validateSubmissionAgreement";

const runValidation = async () => {
	try {
		// Define the file path
		const filePath = path.resolve(__dirname, "./Submission_Agreement_123-123.pdf");

		// Read the PDF file into a buffer
		const fileBuffer = await fs.readFile(filePath);

		// Set the accession and application numbers
		const accession = "444";
		const application = "123";

		// Call the validation function
		await validateSubmissionAgreement({
			buffer: fileBuffer,
			accession,
			application,
		});

		console.log("PDF validation successful!");
	} catch (error) {
		console.error(error.message);
	}
};

// Execute the validation
runValidation();
```

2. Add Submission agreement file from Product Team > Examples in Teams to the same directory as above.

3.  From backend directory run `npm run run-node ./src/modules/transfer/utils/test.ts`

You can edit the accession and application numbers in the test.ts file.

## 🔰 Checklist

- [x] I have read and agree with the following checklist.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
