### PR TITLE
DAP-1028: CreatePSP function

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -23,6 +23,7 @@ module.exports = {
 		"modules/filelist/utils/queueConsumer",
 		"modules/transfer/services/",
 		"modules/transfer/utils/queueConsumer",
+		"modules/transfer/utils/createPSP",
 		"modules/submission-agreement/assets/",
 	],
 	coverageDirectory: "coverage",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
 		"typescript": "5.6.2",
 		"xlsx": "0.18.5",
 		"yauzl": "3.2.0",
+		"yazl": "3.3.1",
 		"zod": "3.23.8"
 	},
 	"devDependencies": {
@@ -38,6 +39,7 @@
 		"@types/pdfkit": "0.13.6",
 		"@types/supertest": "6.0.2",
 		"@types/yauzl": "2.10.3",
+		"@types/yazl": "2.4.5",
 		"nodemon": "3.1.7",
 		"supertest": "7.0.0",
 		"ts-jest": "29.2.5",

--- a/backend/src/modules/transfer/schemas/metadata.ts
+++ b/backend/src/modules/transfer/schemas/metadata.ts
@@ -6,4 +6,4 @@ export const adminMetadataZodSchema = z.object({
 	application: z.string(),
 });
 
-export type FolderMetadataZodType = z.infer<typeof adminMetadataZodSchema>;
+export type AdminMetadataZodType = z.infer<typeof adminMetadataZodSchema>;

--- a/backend/src/modules/transfer/schemas/metadata.ts
+++ b/backend/src/modules/transfer/schemas/metadata.ts
@@ -2,8 +2,6 @@ import { z } from "zod";
 
 // Admin Metadata Zod Schema
 export const adminMetadataZodSchema = z.object({
-	ministry: z.union([z.string(), z.null()]).optional(),
-	branch: z.union([z.string(), z.null()]).optional(),
 	accession: z.string(),
 	application: z.string(),
 });

--- a/backend/src/modules/transfer/utils/createBagitFiles.ts
+++ b/backend/src/modules/transfer/utils/createBagitFiles.ts
@@ -18,7 +18,7 @@ export const createBagitFiles = ({
 	Object.entries(files).forEach(([folder, fileArray]) => {
 		if (folders.includes(folder)) {
 			fileArray.forEach((file: FileMetadataZodType) => {
-				manifestContent += `${file.checksum} data/${file.filepath}\n`;
+				manifestContent += `${file.checksum} data/${(file.filepath).replaceAll("\\", "/")}\n`;
 			});
 		}
 	});

--- a/backend/src/modules/transfer/utils/createBagitFiles.ts
+++ b/backend/src/modules/transfer/utils/createBagitFiles.ts
@@ -1,18 +1,26 @@
 import type { TransferZod } from "@/modules/transfer/entities";
 import type { FileMetadataZodType } from "@/modules/filelist/schemas";
 
-export const createBagitFiles = (
-	files: TransferZod["metadata"]["files"],
-): { bagit: Buffer; manifest: Buffer } => {
+type Props = {
+	files: TransferZod["metadata"]["files"];
+	folders: string[]; // The folder names to include
+};
+
+export const createBagitFiles = ({
+	files,
+	folders,
+}: Props): { bagit: Buffer; manifest: Buffer } => {
 	// Create the content for bagit.txt
 	const bagitContent = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n";
 
 	// Create the content for the manifest file
 	let manifestContent = "";
-	Object.entries(files).forEach(([_, fileArray]) => {
-		fileArray.forEach((file: FileMetadataZodType) => {
-			manifestContent += `${file.checksum} data/${file.filepath}\n`;
-		});
+	Object.entries(files).forEach(([folder, fileArray]) => {
+		if (folders.includes(folder)) {
+			fileArray.forEach((file: FileMetadataZodType) => {
+				manifestContent += `${file.checksum} data/${file.filepath}\n`;
+			});
+		}
 	});
 
 	// Return both buffers

--- a/backend/src/modules/transfer/utils/createBagitFiles.ts
+++ b/backend/src/modules/transfer/utils/createBagitFiles.ts
@@ -13,12 +13,25 @@ export const createBagitFiles = ({
 	// Create the content for bagit.txt
 	const bagitContent = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n";
 
+	const relativeFolderPaths = folders.map((folder) => {
+		const folderNameParts = folder.replaceAll("\\", "/").split("/");
+		const folderName = folderNameParts[folderNameParts.length - 1];
+		return { fullPath: folder.replaceAll("\\", "/"), folderName };
+	});
+
 	// Create the content for the manifest file
 	let manifestContent = "";
 	Object.entries(files).forEach(([folder, fileArray]) => {
 		if (folders.includes(folder)) {
 			fileArray.forEach((file: FileMetadataZodType) => {
-				manifestContent += `${file.checksum} data/${(file.filepath).replaceAll("\\", "/")}\n`;
+				const relativeFolder = relativeFolderPaths.find(
+					(entry) => entry.fullPath === folder.replaceAll("\\", "/"),
+				);
+				let filePath = file.filepath.replaceAll("\\", "/");
+				filePath = filePath
+					// biome-ignore lint/style/noNonNullAssertion: <explanation>
+					.replace(relativeFolder?.fullPath!, relativeFolder?.folderName!);
+				manifestContent += `${file.checksum} data/${filePath}\n`;
 			});
 		}
 	});

--- a/backend/src/modules/transfer/utils/createPSP.ts
+++ b/backend/src/modules/transfer/utils/createPSP.ts
@@ -1,0 +1,78 @@
+import yauzl from "yauzl";
+import yazl from "yazl";
+import { createBagitFiles } from "./createBagitFiles";
+import type { TransferZod } from "../entities";
+import path from "node:path";
+
+type Props = {
+	folderContent: string[];
+	buffer: Buffer;
+	metadata: TransferZod["metadata"];
+};
+
+export const createPSP = async ({ folderContent, buffer, metadata }: Props): Promise<Buffer> => {
+	const bagitFiles = createBagitFiles({ files: metadata.files, folders: folderContent });
+
+	const outputZip = new yazl.ZipFile();
+	const chunks: Buffer[] = [];
+
+	// Open the input ZIP file from the buffer
+	await new Promise<void>((resolve, reject) => {
+		yauzl.fromBuffer(buffer, { lazyEntries: true }, (err, zipFile) => {
+			if (err) return reject(err);
+
+			zipFile.readEntry();
+			zipFile.on("entry", (entry) => {
+				const entryPath = entry.fileName;
+
+				if (entryPath.startsWith("metadata/") || entryPath.startsWith("documentation/")) {
+					zipFile.openReadStream(entry, (err, readStream) => {
+						if (err) return reject(err);
+						const newPath = entryPath
+							.replace("metadata/", "metadata/")
+							.replace("documentation/", "documentation/");
+						const entryChunks: Buffer[] = [];
+						readStream.on("data", (chunk) => entryChunks.push(chunk));
+						readStream.on("end", () => {
+							const fileBuffer = Buffer.concat(entryChunks);
+							outputZip.addBuffer(fileBuffer, newPath);
+							zipFile.readEntry();
+						});
+					});
+				} else if (entryPath.startsWith("content/")) {
+					const folderName = path.basename(entryPath.split("/")[1]);
+					if (folderContent.includes(folderName)) {
+						zipFile.openReadStream(entry, (err, readStream) => {
+							if (err) return reject(err);
+							const newPath = entryPath.replace("content/", "data/");
+							const entryChunks: Buffer[] = [];
+							readStream.on("data", (chunk) => entryChunks.push(chunk));
+							readStream.on("end", () => {
+								const fileBuffer = Buffer.concat(entryChunks);
+								outputZip.addBuffer(fileBuffer, newPath);
+								zipFile.readEntry();
+							});
+						});
+					} else {
+						zipFile.readEntry();
+					}
+				} else {
+					zipFile.readEntry();
+				}
+			});
+
+			zipFile.on("end", () => {
+				outputZip.addBuffer(bagitFiles.bagit, "bagit.txt");
+				outputZip.addBuffer(bagitFiles.manifest, "manifest-sha256.txt");
+				outputZip.end();
+				resolve();
+			});
+		});
+	});
+
+	// Collect the ZIP output
+	outputZip.outputStream.on("data", (chunk) => chunks.push(chunk));
+	await new Promise((resolve) => outputZip.outputStream.on("end", resolve));
+
+	return Buffer.concat(chunks);
+};

--- a/backend/src/modules/transfer/utils/index.ts
+++ b/backend/src/modules/transfer/utils/index.ts
@@ -5,3 +5,4 @@ export * from "./sortPSPContent";
 export * from "./validateSubmissionAgreement";
 export * from "./createBagitFiles";
 export * from "./validateDigitalFileList";
+export * from "./createPSP";

--- a/backend/src/modules/transfer/utils/validateStandardTransferStructure.ts
+++ b/backend/src/modules/transfer/utils/validateStandardTransferStructure.ts
@@ -15,25 +15,25 @@ type FileCheck = {
 
 const fileChecks: FileCheck[] = [
 	{
-		regex: /^(Digital_File_List_|File\sList)/,
+		regex: /^(Digital_File_List|File\sList)/,
 		allowedExtensions: ["xlsx", "json"],
 		parentDirectory: "documentation",
 		errorMessage:
-			"Digital File List (beginning with 'Digital_File_List_' or 'File List') must be included and have a .xlsx or .json extension in the documentation directory.",
+			"Digital File List (beginning with 'Digital_File_List' or 'File List') must be included and have a .xlsx or .json extension in the documentation directory.",
 	},
 	{
-		regex: /^(Transfer_Form_|617)/,
+		regex: /^(Transfer_Form|617)/,
 		allowedExtensions: ["pdf"],
 		parentDirectory: "documentation",
 		errorMessage:
-			"Transfer Form ARS 617 (beginning with 'Transfer_Form_' or '617') must be included and have a .pdf extension in the documentation directory.",
+			"Transfer Form ARS 617 (beginning with 'Transfer_Form' or '617') must be included and have a .pdf extension in the documentation directory.",
 	},
 	{
-		regex: /^Submission_Agreement_/,
+		regex: /^Submission_Agreement/,
 		allowedExtensions: ["pdf"],
 		parentDirectory: "documentation",
 		errorMessage:
-			"Submission Agreement (beginning with 'Submission_Agreement_') must be included and have a .pdf extension in the documentation directory.",
+			"Submission Agreement (beginning with 'Submission_Agreement') must be included and have a .pdf extension in the documentation directory.",
 	},
 	{
 		regex: /^admin/,

--- a/backend/tests/modules/transfer/schemas/metadata.test.ts
+++ b/backend/tests/modules/transfer/schemas/metadata.test.ts
@@ -4,30 +4,8 @@ import { z } from "zod";
 describe("adminMetadataZodSchema", () => {
 	it("should validate a correct admin metadata object", () => {
 		const validData = {
-			ministry: "Ministry of Health",
-			branch: "IT Branch",
 			accession: "ACC-1234",
 			application: "App-01",
-		};
-
-		expect(() => adminMetadataZodSchema.parse(validData)).not.toThrow();
-	});
-
-	it("should validate when optional fields are missing", () => {
-		const validData = {
-			accession: "ACC-5678",
-			application: "App-02",
-		};
-
-		expect(() => adminMetadataZodSchema.parse(validData)).not.toThrow();
-	});
-
-	it("should validate when optional fields are null", () => {
-		const validData = {
-			ministry: null,
-			branch: null,
-			accession: "ACC-91011",
-			application: "App-03",
 		};
 
 		expect(() => adminMetadataZodSchema.parse(validData)).not.toThrow();
@@ -44,8 +22,6 @@ describe("adminMetadataZodSchema", () => {
 
 	it("should throw an error if accession is not a string", () => {
 		const invalidData = {
-			ministry: "Ministry of Finance",
-			branch: "Admin Branch",
 			accession: 12345, // Invalid type
 			application: "App-04",
 		};
@@ -55,32 +31,8 @@ describe("adminMetadataZodSchema", () => {
 
 	it("should throw an error if application is not a string", () => {
 		const invalidData = {
-			ministry: "Ministry of Transportation",
-			branch: "Operations Branch",
 			accession: "ACC-121314",
 			application: 67890, // Invalid type
-		};
-
-		expect(() => adminMetadataZodSchema.parse(invalidData)).toThrowError(z.ZodError);
-	});
-
-	it("should throw an error if ministry is not a string or null", () => {
-		const invalidData = {
-			ministry: 123, // Invalid type
-			branch: "IT Branch",
-			accession: "ACC-151617",
-			application: "App-05",
-		};
-
-		expect(() => adminMetadataZodSchema.parse(invalidData)).toThrowError(z.ZodError);
-	});
-
-	it("should throw an error if branch is not a string or null", () => {
-		const invalidData = {
-			ministry: "Ministry of Environment",
-			branch: 456, // Invalid type
-			accession: "ACC-181920",
-			application: "App-06",
 		};
 
 		expect(() => adminMetadataZodSchema.parse(invalidData)).toThrowError(z.ZodError);

--- a/backend/tests/modules/transfer/utils/createBagitFiles.test.ts
+++ b/backend/tests/modules/transfer/utils/createBagitFiles.test.ts
@@ -3,9 +3,9 @@ import type { TransferZod } from "@/modules/transfer/entities";
 
 // Mock files data for testing
 const mockFiles: TransferZod["metadata"]["files"] = {
-	group1: [
+	"C:/data/documents": [
 		{
-			filepath: "documents/report1.pdf",
+			filepath: "C:/data/documents/report1.pdf",
 			filename: "report1.pdf",
 			size: "1024",
 			checksum: "abc123def456",
@@ -21,9 +21,9 @@ const mockFiles: TransferZod["metadata"]["files"] = {
 			programName: "PDF Editor",
 		},
 	],
-	group2: [
+	"C:/data/images": [
 		{
-			filepath: "images/photo1.jpg",
+			filepath: "C:/data/images/photo1.jpg",
 			filename: "photo1.jpg",
 			size: "2048",
 			checksum: "789ghi012jkl",
@@ -45,14 +45,14 @@ describe("createBagitFiles", () => {
 	// Test suite for createBagitFiles
 
 	it("should generate a valid bagit.txt buffer", () => {
-		const folders = ["group1", "group2"];
+		const folders = ["C:/data/documents", "C:/data/images"];
 		const result = createBagitFiles({ files: mockFiles, folders });
 		const expectedBagit = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n";
 		expect(result.bagit.toString()).toBe(expectedBagit);
 	});
 
 	it("should generate a valid manifest.txt buffer for included folders", () => {
-		const folders = ["group1", "group2"];
+		const folders = ["C:/data/documents", "C:/data/images"];
 		const result = createBagitFiles({ files: mockFiles, folders });
 		const expectedManifest =
 			"abc123def456 data/documents/report1.pdf\n" + "789ghi012jkl data/images/photo1.jpg\n";
@@ -60,16 +60,23 @@ describe("createBagitFiles", () => {
 	});
 
 	it("should generate an empty manifest.txt buffer if no folders match", () => {
-		const folders = ["group3"]; // Non-existent folder
+		const folders = ["C:/data/nonexistent"]; // Non-existent folder
 		const result = createBagitFiles({ files: mockFiles, folders });
 		const expectedManifest = ""; // No matching folders
 		expect(result.manifest.toString()).toBe(expectedManifest);
 	});
 
 	it("should only include files from specified folders in the manifest.txt buffer", () => {
-		const folders = ["group1"]; // Only include files from group1
+		const folders = ["C:/data/documents"]; // Only include files from documents
 		const result = createBagitFiles({ files: mockFiles, folders });
-		const expectedManifest = "abc123def456 data/documents/report1.pdf\n"; // Only group1 files
+		const expectedManifest = "abc123def456 data/documents/report1.pdf\n"; // Only documents
+		expect(result.manifest.toString()).toBe(expectedManifest);
+	});
+
+	it("should correctly map folder names and replace paths in the manifest.txt buffer", () => {
+		const folders = ["C:/data/images"];
+		const result = createBagitFiles({ files: mockFiles, folders });
+		const expectedManifest = "789ghi012jkl data/images/photo1.jpg\n"; // Correctly mapped
 		expect(result.manifest.toString()).toBe(expectedManifest);
 	});
 });

--- a/backend/tests/modules/transfer/utils/createBagitFiles.test.ts
+++ b/backend/tests/modules/transfer/utils/createBagitFiles.test.ts
@@ -45,15 +45,31 @@ describe("createBagitFiles", () => {
 	// Test suite for createBagitFiles
 
 	it("should generate a valid bagit.txt buffer", () => {
-		const result = createBagitFiles(mockFiles);
+		const folders = ["group1", "group2"];
+		const result = createBagitFiles({ files: mockFiles, folders });
 		const expectedBagit = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n";
 		expect(result.bagit.toString()).toBe(expectedBagit);
 	});
 
-	it("should generate a valid manifest.txt buffer", () => {
-		const result = createBagitFiles(mockFiles);
+	it("should generate a valid manifest.txt buffer for included folders", () => {
+		const folders = ["group1", "group2"];
+		const result = createBagitFiles({ files: mockFiles, folders });
 		const expectedManifest =
 			"abc123def456 data/documents/report1.pdf\n" + "789ghi012jkl data/images/photo1.jpg\n";
+		expect(result.manifest.toString()).toBe(expectedManifest);
+	});
+
+	it("should generate an empty manifest.txt buffer if no folders match", () => {
+		const folders = ["group3"]; // Non-existent folder
+		const result = createBagitFiles({ files: mockFiles, folders });
+		const expectedManifest = ""; // No matching folders
+		expect(result.manifest.toString()).toBe(expectedManifest);
+	});
+
+	it("should only include files from specified folders in the manifest.txt buffer", () => {
+		const folders = ["group1"]; // Only include files from group1
+		const result = createBagitFiles({ files: mockFiles, folders });
+		const expectedManifest = "abc123def456 data/documents/report1.pdf\n"; // Only group1 files
 		expect(result.manifest.toString()).toBe(expectedManifest);
 	});
 });

--- a/backend/tests/modules/transfer/utils/validateMetadataFiles.test.ts
+++ b/backend/tests/modules/transfer/utils/validateMetadataFiles.test.ts
@@ -1,51 +1,58 @@
 import { validateMetadataFiles } from "@/modules/transfer/utils/validateMetadataFiles";
-import JSZip from "jszip";
+import { Buffer } from "node:buffer";
+import yazl from "yazl";
 
 describe("validateMetadataFiles", () => {
+	// Helper function to create a zip buffer using yazl (compatible with yauzl for reading)
+	const createZipBuffer = (files: Record<string, string>): Promise<Buffer> => {
+		return new Promise((resolve, reject) => {
+			const buffers: Buffer[] = [];
+			const zipFile = new yazl.ZipFile();
+
+			for (const [filePath, content] of Object.entries(files)) {
+				zipFile.addBuffer(Buffer.from(content), filePath);
+			}
+
+			zipFile.outputStream
+				.on("data", (chunk) => buffers.push(chunk))
+				.on("end", () => resolve(Buffer.concat(buffers)))
+				.on("error", (err) => reject(err));
+
+			zipFile.end();
+		});
+	};
+
 	// Test case: Valid zip file with correct metadata
 	it("should validate successfully with a valid zip file containing correct metadata", async () => {
-		const zip = new JSZip();
-
-		// Add valid "metadata/" folder and files
-		// biome-ignore lint/style/noNonNullAssertion: <explanation>
-		zip
-			.folder("metadata")!
-			.file(
-				"admin.json",
-				JSON.stringify({
-					ministry: "Test Ministry",
-					branch: "Test Branch",
-					accession: "valid-accession",
-					application: "valid-application",
-				}),
-			)
-			.file(
-				"files.json",
-				JSON.stringify({
-					file1: [
-						{
-							filepath: "/path/to/file",
-							filename: "file.txt",
-							size: "1234",
-							checksum: "abcd1234",
-							birthtime: "2023-01-01",
-							lastModified: "2023-01-01",
-							lastAccessed: "2023-01-01",
-						},
-					],
-				}),
-			)
-			.file(
-				"folders.json",
-				JSON.stringify({
-					folder1: {
-						schedule: "2023",
-						classification: "confidential",
+		const files = {
+			"metadata/admin.json": JSON.stringify({
+				ministry: "Test Ministry",
+				branch: "Test Branch",
+				accession: "valid-accession",
+				application: "valid-application",
+			}),
+			"metadata/files.json": JSON.stringify({
+				file1: [
+					{
+						filepath: "/path/to/file",
+						filename: "file.txt",
+						size: "1234",
+						checksum: "abcd1234",
+						birthtime: "2023-01-01",
+						lastModified: "2023-01-01",
+						lastAccessed: "2023-01-01",
 					},
-				}),
-			);
+				],
+			}),
+			"metadata/folders.json": JSON.stringify({
+				folder1: {
+					schedule: "2023",
+					classification: "confidential",
+				},
+			}),
+		};
 
-		const buffer = await zip.generateAsync({ type: "nodebuffer" });
+		const buffer = await createZipBuffer(files);
 
 		await expect(
 			validateMetadataFiles({
@@ -58,10 +65,11 @@ describe("validateMetadataFiles", () => {
 
 	// Test case: Missing required files in "metadata/"
 	it('should throw an error if required files are missing in "metadata/"', async () => {
-		const zip = new JSZip();
-		// biome-ignore lint/style/noNonNullAssertion: <explanation>
-		zip.folder("metadata")!.file("admin.json", "{}");
-		const buffer = await zip.generateAsync({ type: "nodebuffer" });
+		const files = {
+			"metadata/admin.json": "{}",
+		};
+
+		const buffer = await createZipBuffer(files);
 
 		await expect(
 			validateMetadataFiles({
@@ -69,21 +77,18 @@ describe("validateMetadataFiles", () => {
 				accession: "valid-accession",
 				application: "valid-application",
 			}),
-		).rejects.toThrowError(
-			new Error("metadata/ is missing the following required files: files.json, folders.json."),
-		);
+		).rejects.toThrowError(/The zip file is missing required file: metadata\/files\.json/);
 	});
 
 	// Test case: Invalid admin.json
 	it("should throw an error if admin.json is invalid", async () => {
-		const zip = new JSZip();
-		// biome-ignore lint/style/noNonNullAssertion: <explanation>
-		zip
-			.folder("metadata")!
-			.file("admin.json", JSON.stringify({}))
-			.file("files.json", JSON.stringify({}))
-			.file("folders.json", JSON.stringify({}));
-		const buffer = await zip.generateAsync({ type: "nodebuffer" });
+		const files = {
+			"metadata/admin.json": JSON.stringify({}),
+			"metadata/files.json": JSON.stringify({}),
+			"metadata/folders.json": JSON.stringify({}),
+		};
+
+		const buffer = await createZipBuffer(files);
 
 		await expect(
 			validateMetadataFiles({
@@ -91,27 +96,23 @@ describe("validateMetadataFiles", () => {
 				accession: "valid-accession",
 				application: "valid-application",
 			}),
-		).rejects.toThrowError("Validation failed for admin.json:");
+		).rejects.toThrowError(/Validation failed for admin\.json/);
 	});
 
 	// Test case: Incorrect accession or application in admin.json
 	it("should throw an error if accession or application in admin.json is incorrect", async () => {
-		const zip = new JSZip();
-		// biome-ignore lint/style/noNonNullAssertion: <explanation>
-		zip
-			.folder("metadata")!
-			.file(
-				"admin.json",
-				JSON.stringify({
-					ministry: null,
-					branch: null,
-					accession: "wrong-accession",
-					application: "wrong-application",
-				}),
-			)
-			.file("files.json", JSON.stringify({}))
-			.file("folders.json", JSON.stringify({}));
-		const buffer = await zip.generateAsync({ type: "nodebuffer" });
+		const files = {
+			"metadata/admin.json": JSON.stringify({
+				ministry: "Test Ministry",
+				branch: "Test Branch",
+				accession: "wrong-accession",
+				application: "wrong-application",
+			}),
+			"metadata/files.json": JSON.stringify({}),
+			"metadata/folders.json": JSON.stringify({}),
+		};
+
+		const buffer = await createZipBuffer(files);
 
 		await expect(
 			validateMetadataFiles({
@@ -119,6 +120,6 @@ describe("validateMetadataFiles", () => {
 				accession: "valid-accession",
 				application: "valid-application",
 			}),
-		).rejects.toThrowError("The accession or application values in admin.json are incorrect.");
+		).rejects.toThrowError(/The accession or application values in admin\.json are incorrect/);
 	});
 });

--- a/backend/tests/modules/transfer/utils/validateStandardTransferStructure.test.ts
+++ b/backend/tests/modules/transfer/utils/validateStandardTransferStructure.test.ts
@@ -13,9 +13,9 @@ describe("validateStandardTransferStructure", () => {
 
 		const mockEntries = [
 			{ fileName: "content/sample.txt" },
-			{ fileName: "documentation/Digital_File_List_.xlsx" },
-			{ fileName: "documentation/Transfer_Form_.pdf" },
-			{ fileName: "documentation/Submission_Agreement_.pdf" },
+			{ fileName: "documentation/Digital_File_List.xlsx" },
+			{ fileName: "documentation/Transfer_Form.pdf" },
+			{ fileName: "documentation/Submission_Agreement.pdf" },
 			{ fileName: "metadata/admin.json" },
 			{ fileName: "metadata/files.json" },
 			{ fileName: "metadata/folders.json" },
@@ -42,7 +42,7 @@ describe("validateStandardTransferStructure", () => {
 	it("should reject if the zip file is missing required directories", async () => {
 		const buffer = Buffer.from("fake buffer");
 
-		const mockEntries = [{ fileName: "documentation/Digital_File_List_.xlsx" }];
+		const mockEntries = [{ fileName: "documentation/Digital_File_List.xlsx" }];
 
 		(yauzl.fromBuffer as jest.Mock).mockImplementation((_, __, callback) => {
 			const mockZipFile = {
@@ -72,7 +72,7 @@ describe("validateStandardTransferStructure", () => {
 
 		const mockEntries = [
 			{ fileName: "content/sample.txt" },
-			{ fileName: "documentation/Transfer_Form_.pdf" },
+			{ fileName: "documentation/Transfer_Form.pdf" },
 			{ fileName: "metadata/admin.json" },
 		];
 
@@ -93,7 +93,7 @@ describe("validateStandardTransferStructure", () => {
 		await expect(validateStandardTransferStructure({ buffer })).rejects.toThrow(
 			new HttpError(
 				HTTP_STATUS_CODES.BAD_REQUEST,
-				`The zip file is missing required files: Digital File List (beginning with 'Digital_File_List_' or 'File List') must be included and have a .xlsx or .json extension in the documentation directory. Submission Agreement (beginning with 'Submission_Agreement_') must be included and have a .pdf extension in the documentation directory. files.json must be included in the metadata directory. folders.json must be included in the metadata directory.`,
+				`The zip file is missing required files: Digital File List (beginning with 'Digital_File_List' or 'File List') must be included and have a .xlsx or .json extension in the documentation directory. Submission Agreement (beginning with 'Submission_Agreement') must be included and have a .pdf extension in the documentation directory. files.json must be included in the metadata directory. folders.json must be included in the metadata directory.`,
 			),
 		);
 	});


### PR DESCRIPTION
## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[DAP-1028](https://citz-cirmo.atlassian.net/browse/DAP-1028)

<!-- PROVIDE BELOW an explanation of your changes and any supporting images -->
A zip of test files can be found at https://bcgov.sharepoint.com/:u:/r/teams/04164-ProjectTeam/Shared%20Documents/Project%20Team/Examples/[Standard_Transfer_Test1.zip](https://bcgov.sharepoint.com/:u:/r/teams/04164-ProjectTeam/Shared%20Documents/Project%20Team/Examples/Standard_Transfer_Test1.zip?csf=1&web=1&e=TRtakT)?csf=1&web=1&e=TRtakT

This PR is about the function `createPSP` however the test file allows you to create the entire Transfer folder (the one that an archivist would review).

The zip file found at that link can be unzipped. Place all files in `backend\src\modules\transfer\utils\` and run `npm run run-node src/modules/transfer/utils/test.ts` from `backend`.

This will use `metadata.ts` as a mock for what the metadata of a request (or the metadata stored in Mongo) would provide.
This will use `Test.zip` as a mock of the `Standard Transfer` files.

`test.ts` will run validation of the `Standard Transfer`, determine which PSPs need to be created, and create the final transfer package (`TR_123_123`).

## 🔰 Checklist

- [x] I have read and agree with the following checklist.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
