### PR TITLE
DAP-1057: Added getFilenameByRegex

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -23,6 +23,7 @@ module.exports = {
 		"modules/filelist/utils/queueConsumer",
 		"modules/transfer/services/",
 		"modules/transfer/utils/queueConsumer",
+		"modules/transfer/utils/getFilenameByRegex",
 		"modules/submission-agreement/assets/",
 	],
 	coverageDirectory: "coverage",

--- a/backend/src/modules/transfer/utils/getFilenameByRegex.ts
+++ b/backend/src/modules/transfer/utils/getFilenameByRegex.ts
@@ -1,0 +1,47 @@
+import yauzl from "yauzl";
+
+type Props = {
+	buffer: Buffer;
+	directory: string;
+	regex: RegExp;
+};
+
+export const getFilenameByRegex = async ({
+	buffer,
+	directory,
+	regex,
+}: Props): Promise<string | null> => {
+	return new Promise((resolve, reject) => {
+		yauzl.fromBuffer(buffer, { lazyEntries: true }, (err, zipFile) => {
+			if (err) return reject(err);
+
+			if (!zipFile) return reject(new Error("Invalid zip file"));
+
+			let matchedFilename: string | null = null;
+
+			zipFile.readEntry();
+
+			zipFile.on("entry", (entry) => {
+				const isInDirectory = entry.fileName.startsWith(directory);
+				if (isInDirectory) {
+					const relativeFilename = entry.fileName.slice(directory.length);
+					if (regex.test(relativeFilename)) {
+						matchedFilename = relativeFilename;
+						zipFile.close();
+						resolve(matchedFilename); // Immediately resolve when a match is found
+						return;
+					}
+				}
+				zipFile.readEntry();
+			});
+
+			zipFile.on("end", () => {
+				resolve(matchedFilename);
+			});
+
+			zipFile.on("error", (zipErr) => {
+				reject(zipErr);
+			});
+		});
+	});
+};

--- a/backend/src/modules/transfer/utils/index.ts
+++ b/backend/src/modules/transfer/utils/index.ts
@@ -6,3 +6,4 @@ export * from "./validateSubmissionAgreement";
 export * from "./createBagitFiles";
 export * from "./validateDigitalFileList";
 export * from "./isChecksumValid";
+export * from "./getFilenameByRegex";


### PR DESCRIPTION
## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[DAP-1057](https://citz-cirmo.atlassian.net/browse/DAP-1057)

<!-- PROVIDE BELOW an explanation of your changes and any supporting images -->

Test using `backend/src/modules/transfer/utils/test.ts` along with `test.zip` from the teams files and run `npm run run-node src/modules/transfer/utils/test.ts` from `backend`.

`// test.ts`

```
import { readFile } from "node:fs/promises";
import { resolve } from "node:path";
import { HttpError } from "@bcgov/citz-imb-express-utilities";
import { getFilenameByRegex } from "./getFilenameByRegex";

/**
 * Converts a file located relative to __dirname into a buffer.
 * @param relativePath - The relative path to the file (from __dirname).
 * @returns A Promise that resolves to a Buffer containing the file's data.
 */
const fileToBuffer = async (relativePath: string): Promise<Buffer> => {
	try {
		// Resolve the file path relative to the current directory
		const filePath = resolve(__dirname, relativePath);

		// Read the file and return it as a buffer
		const fileBuffer = await readFile(filePath);
		return fileBuffer;
	} catch (error) {
		console.error(`Error reading file at ${relativePath}:`, error);
		throw error;
	}
};

// Usage example
(async () => {
	try {
		const buffer = await fileToBuffer("./Test.zip");

		const filelistName = await getFilenameByRegex({
			buffer,
			directory: "documentation/",
			regex: /^(Digital_File_List_|File\sList)/,
		});

		const subAgreementName = await getFilenameByRegex({
			buffer,
			directory: "documentation/",
			regex: /^Submission_Agreement_/,
		});

		console.log("Found files:", filelistName, subAgreementName);
	} catch (error) {
		if (error instanceof HttpError) console.error(error.message);
		else console.log(error);
	}
})();
```

## 🔰 Checklist

- [x] I have read and agree with the following checklist.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
