### PR TITLE
DAP-1042: Add owner metadata

### DIFF
--- a/desktop/src/main/fileProcessing/WorkerPool.ts
+++ b/desktop/src/main/fileProcessing/WorkerPool.ts
@@ -62,6 +62,9 @@ export class WorkerPool extends EventEmitter {
         const task = workerScript.includes("metadata") ? "metadata" : "copy";
         // Handle progress updates
         if (message.type === "progress") {
+          console.log(
+            `Progress ${message.progressPercentage} from ${message.source} message emitted.`
+          );
           this.emit("progress", {
             task,
             ...message,

--- a/desktop/src/main/fileProcessing/workers/utilities/generateMetadataInBatches.ts
+++ b/desktop/src/main/fileProcessing/workers/utilities/generateMetadataInBatches.ts
@@ -12,10 +12,6 @@ const { stat, readdir } = fsPromises;
 
 let processedFileCount = 0;
 
-const { stat, readdir } = fsPromises;
-
-let processedFileCount = 0;
-
 export const generateMetadataInBatches = async (
   rootDir: string,
   originalSource: string,


### PR DESCRIPTION
## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[DAP-1042](https://citz-cirmo.atlassian.net/browse/DAP-1042)

<!-- PROVIDE BELOW an explanation of your changes and any supporting images -->
Adds owner metadata field to the file list on windows.

To test, run `npm run build` before running the application. Then, add a folder to create file list and hit continue. Wait for the file list in your email and confirm that it includes `Owner` field on the `METADATA` sheet.

## 🔰 Checklist

- [x] I have read and agree with the following checklist.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
