### PR TITLE
DAP-1155: Prevent existing folder upload

### DIFF
--- a/desktop/src/renderer/src/pages/transfers/LanTransfer.tsx
+++ b/desktop/src/renderer/src/pages/transfers/LanTransfer.tsx
@@ -367,12 +367,12 @@ export const LanTransferPage = () => {
 
   const handleEditClick = async (folderPath: string): Promise<void> => {
     const result = await api.selectDirectory({ singleSelection: true });
+    const selectedFolderPath = result[0];
 
-    // Cancel if no folder path is selected.
-    if (!result[0]) return;
+    if (!selectedFolderPath) return;
 
     // Folder already exists in file list.
-    if (folders.some((row) => row.folder === result[0])) {
+    if (folders.some((row) => row.folder === selectedFolderPath)) {
       toast.error(Toast, {
         data: {
           title: "Folder edit unsuccessful",
@@ -386,7 +386,7 @@ export const LanTransferPage = () => {
     setFolders((prev) =>
       prev.map((row) => {
         if (row.folder === folderPath)
-          return { ...row, folder: result[0], invalidPath: false };
+          return { ...row, folder: selectedFolderPath, invalidPath: false };
         return row;
       })
     );
@@ -394,11 +394,11 @@ export const LanTransferPage = () => {
       ...prev,
       {
         originalFolderPath: folderPath,
-        newFolderPath: result[0],
+        newFolderPath: selectedFolderPath,
         deleted: false,
       },
     ]);
-    setFoldersToProcess((prev) => [...prev, result[0]]);
+    setFoldersToProcess((prev) => [...prev, selectedFolderPath]);
   };
 
   const parseFileList = async () => {

--- a/desktop/src/renderer/src/pages/transfers/LanTransfer.tsx
+++ b/desktop/src/renderer/src/pages/transfers/LanTransfer.tsx
@@ -360,8 +360,23 @@ export const LanTransferPage = () => {
     return newFolder;
   };
 
-  const handleEditClick = async (folderPath: string) => {
+  const handleEditClick = async (folderPath: string): Promise<void> => {
     const result = await api.selectDirectory({ singleSelection: true });
+
+    // Cancel if no folder path is selected.
+    if (!result[0]) return;
+
+    // Folder already exists in file list.
+    if (folders.some((row) => row.folder === result[0])) {
+      toast.error(Toast, {
+        data: {
+          title: "Folder edit unsuccessful",
+          message:
+            "The folder path you selected is already used in the file list. Please select a different folder path.",
+        },
+      });
+      return;
+    }
 
     setFolders((prev) =>
       prev.map((row) => {


### PR DESCRIPTION
## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[DAP-1155](https://citz-cirmo.atlassian.net/browse/DAP-1155)

<!-- PROVIDE BELOW an explanation of your changes and any supporting images -->
- Verified toast message with Isabella
- Prevents an existing folder from being selected in the edit path menu on the LAN transfer confirmation step.
- Resolves issue where backing out of Edit menu causes folder field to become blank.

## 🔰 Checklist

- [x] I have read and agree with the following checklist.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
