### PR TITLE
DAP-1108: Send extended metadata lan transfer

### DIFF
--- a/desktop/src/renderer/src/pages/transfers/LanTransfer.tsx
+++ b/desktop/src/renderer/src/pages/transfers/LanTransfer.tsx
@@ -56,6 +56,9 @@ export const LanTransferPage = () => {
 
   // File list
   const [metadata, setMetadata] = useState<Record<string, unknown>>({});
+  const [extendedMetadata, setExtendedMetadata] = useState<
+    Record<string, unknown>
+  >({});
   const [originalFolderList, setOriginalFolderList] = useState<
     Record<string, unknown>
   >({});
@@ -135,16 +138,24 @@ export const LanTransferPage = () => {
         source: string;
         success: boolean;
         metadata?: Record<string, unknown>;
+        extendedMetadata?: Record<string, unknown>;
         error?: unknown;
       }>
     ) => {
-      const { source, success, metadata: newMetadata, error } = event.detail;
+      const {
+        source,
+        success,
+        metadata: newMetadata,
+        extendedMetadata: newExtendedMetadata,
+        error,
+      } = event.detail;
 
       if (success && newMetadata) {
         setMetadata((prev) => ({
           ...prev,
           [source]: newMetadata[source],
         }));
+        if (newExtendedMetadata) setExtendedMetadata(newExtendedMetadata);
         console.log(`Successfully processed folder metadata: ${source}`);
       } else {
         console.error(`Failed to process folder metadata: ${source}`, {
@@ -524,6 +535,7 @@ export const LanTransferPage = () => {
       setConfirmAccAppChecked(false);
       setFolders([]);
       setMetadata({});
+      setExtendedMetadata({});
       return;
     }
     parseFileList();
@@ -631,6 +643,7 @@ export const LanTransferPage = () => {
       JSON.stringify(originalFolderList)
     );
     formData.append("metadataV2", JSON.stringify(metadataV2));
+    formData.append("extendedMetadata", JSON.stringify(extendedMetadata));
     formData.append("changes", JSON.stringify(changes));
     formData.append("changesJustification", changesJustification);
 


### PR DESCRIPTION
## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[DAP-1108](https://citz-cirmo.atlassian.net/browse/DAP-1108)

<!-- PROVIDE BELOW an explanation of your changes and any supporting images -->
- Sends extendedMetadata to lan transfer endpoint when doing the `Send records` > `Lan Transfer` flow in the app

## 🔰 Checklist

- [x] I have read and agree with the following checklist.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
