### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -121,7 +121,12 @@ jobs:
         run: |
           cd desktop/dist
           for file in *; do
-            mv "$file" "$(echo "$file" | tr ' ' '-')"
+            if [ -f "$file" ]; then
+              new_name=$(echo "$file" | tr ' ' '-')
+              if [ "$file" != "$new_name" ]; then
+                mv "$file" "$new_name"
+              fi
+            fi
           done
 
       # Upload artifacts


### PR DESCRIPTION
## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  

<!-- PROVIDE BELOW an explanation of your changes and any supporting images -->
The script was encountering an error because mv is trying to rename a directory (mac-arm64) to itself (mac-arm64/mac-arm64), which is invalid.

## 🔰 Checklist

- [ ] I have read and agree with the following checklist.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
