### PR TITLE
DAP-1199: Reset progress on change page

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -481,8 +481,8 @@ app.whenReady().then(() => {
         type: "question",
         title: "Update Ready",
         message:
-          "An update has been downloaded. Do you want to install it now?",
-        buttons: ["Restart & Install", "Later"],
+          "An update has been downloaded. Please update before continuing.",
+        buttons: ["Restart and Install"],
       })
       .then((result) => {
         if (result.response === 0) {

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -112,6 +112,11 @@ function App(): JSX.Element {
     };
   }, []);
 
+  // Reset progress made when route is changed
+  useEffect(() => {
+    setProgressMade(false);
+  }, [currentPath]);
+
   return (
     <Grid container sx={{ height: "100vh" }}>
       <VPNPopup open={showVPNPopup} />


### PR DESCRIPTION
## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[DAP-1199](https://citz-cirmo.atlassian.net/browse/DAP-1199)

<!-- PROVIDE BELOW an explanation of your changes and any supporting images -->
Resets the progress made when changing a page. Progress made is used to control if the "Confirm leave page" modal appears.

## 🔰 Checklist

- [x] I have read and agree with the following checklist.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
